### PR TITLE
Add argument to login to Instaloader

### DIFF
--- a/src/instawebhooks/__main__.py
+++ b/src/instawebhooks/__main__.py
@@ -15,7 +15,7 @@ from .parser import parser
 try:
     from aiohttp import ClientSession
     from discord import Embed, File, SyncWebhook
-    from instaloader.exceptions import LoginRequiredException
+    from instaloader.exceptions import LoginException, LoginRequiredException
     from instaloader.instaloader import Instaloader
     from instaloader.structures import Post, Profile
 except ModuleNotFoundError as exc:
@@ -44,6 +44,19 @@ elif args.verbose:
     logger.debug("Verbose output enabled.")
 else:
     logger.setLevel(logging.INFO)
+
+if args.login:
+    logger.info("Logging into Instagram...")
+    try:
+        Instaloader().interactive_login(args.login)
+    except LoginException as login_exc:
+        logger.critical("instaloader: error: %s", login_exc)
+        raise SystemExit(
+            "An error happened during login. Check if the provided username exists."
+        ) from login_exc
+    except KeyboardInterrupt:
+        print("\nLogin interrupted by user.")
+        sys.exit(0)
 
 # Log the start of the program
 logger.info("Starting InstaWebhooks...")
@@ -207,7 +220,7 @@ def main():
     except LoginRequiredException as login_exc:
         logger.critical("instaloader: error: %s", login_exc)
         raise SystemExit(
-            "Not logged into Instaloader.\n  instaloader --login YOUR-USERNAME"
+            "Not logged in. Please login with the --login flag."
         ) from login_exc
     except KeyboardInterrupt:
         print("\nInterrupted by user.")

--- a/src/instawebhooks/__main__.py
+++ b/src/instawebhooks/__main__.py
@@ -45,10 +45,13 @@ elif args.verbose:
 else:
     logger.setLevel(logging.INFO)
 
-if args.login:
+if args.login or args.interactive_login:
     logger.info("Logging into Instagram...")
     try:
-        Instaloader().interactive_login(args.login)
+        if args.login:
+            Instaloader().login(*args.login)
+        if args.interactive_login:
+            Instaloader().interactive_login(args.interactive_login)
     except LoginException as login_exc:
         logger.critical("instaloader: error: %s", login_exc)
         raise SystemExit(

--- a/src/instawebhooks/parser.py
+++ b/src/instawebhooks/parser.py
@@ -47,9 +47,17 @@ group.add_argument("-v", "--verbose", help="show debug logging", action="store_t
 parser.add_argument(
     "-l",
     "--login",
+    metavar=("USERNAME", "PASSWORD"),
+    type=str,
+    help="login to instagram with username and password",
+    nargs=2,
+)
+parser.add_argument(
+    "-t",
+    "--interactive-login",
     metavar="USERNAME",
     type=str,
-    help="login to instagram with username",
+    help="login to instagram with username and ask for password on terminal",
 )
 parser.add_argument(
     "-p",

--- a/src/instawebhooks/parser.py
+++ b/src/instawebhooks/parser.py
@@ -45,9 +45,17 @@ parser.add_argument(
 group.add_argument("-q", "--quiet", help="hide all logging", action="store_true")
 group.add_argument("-v", "--verbose", help="show debug logging", action="store_true")
 parser.add_argument(
+    "-l",
+    "--login",
+    metavar="USERNAME",
+    type=str,
+    help="login to instagram with username",
+)
+parser.add_argument(
     "-p",
     "--catchup",
     help="send the last latest posts on startup regardless of time",
+    metavar="POSTS",
     type=int,
     default=0,
 )

--- a/src/instawebhooks/parser.py
+++ b/src/instawebhooks/parser.py
@@ -29,7 +29,8 @@ parser = ArgumentParser(
     ),
     epilog="https://github.com/RaenLua/InstaWebhooks",
 )
-group = parser.add_mutually_exclusive_group()
+logging_group = parser.add_mutually_exclusive_group()
+login_group = parser.add_mutually_exclusive_group()
 parser.add_argument(
     "instagram_username",
     help="the Instagram username to monitor for new posts",
@@ -42,9 +43,13 @@ parser.add_argument(
         r"^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_.-]*)$"
     ),
 )
-group.add_argument("-q", "--quiet", help="hide all logging", action="store_true")
-group.add_argument("-v", "--verbose", help="show debug logging", action="store_true")
-parser.add_argument(
+logging_group.add_argument(
+    "-q", "--quiet", help="hide all logging", action="store_true"
+)
+logging_group.add_argument(
+    "-v", "--verbose", help="show debug logging", action="store_true"
+)
+login_group.add_argument(
     "-l",
     "--login",
     metavar=("USERNAME", "PASSWORD"),
@@ -52,7 +57,7 @@ parser.add_argument(
     help="login to instagram with username and password",
     nargs=2,
 )
-parser.add_argument(
+login_group.add_argument(
     "-t",
     "--interactive-login",
     metavar="USERNAME",


### PR DESCRIPTION
## Description

Adds a new argument to start an interactive login with Instaloader.

## Related Issues

Closes #16 

## Changes Made

* Add new `--login` argument which takes a username
* Update previous arguments to use argparse [`metavar`](https://docs.python.org/3/library/argparse.html#metavar) when needed
* Add logic for logging in using Instaloader with [`interactive_login()`](https://instaloader.github.io/module/instaloader.html#instaloader.Instaloader.interactive_login)

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

Related to https://github.com/RyanLua/InstaWebhooks/discussions/15