### PR TITLE
Add post placeholders to usage documentation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -62,3 +62,14 @@ Reference
 
         * ``https://discord.com/api/webhooks/{webhook_id}/{webhook_token}``
         * ``https://discordapp.com/api/webhooks/{webhook_id}/{webhook_token}``
+
+   -c --message-content : @after
+        Accepts placeholders for the post information:
+
+        * ``{post_url}`` - The URL to the post on Instagram: ``https://www.instagram.com/C8wRGmyR-6N``
+        * ``{owner_url}`` - The URL to the owner's profile on Instagram: ``https://www.instagram.com/raenlua``
+        * ``{owner_name}`` - The owner's full name: ``Ryan Luu``
+        * ``{owner_username}`` - The owner's username: ``raenlua``
+        * ``{post_caption}`` - The post's caption: ``This is a post caption.``
+        * ``{post_shortcode}`` - The post's shortcode: ``C8wRGmyR-6N``
+        * ``{post_image_url}`` - The post's image URL: ``https://www.instagram.com/p/C8wRGmyR-6N/media``


### PR DESCRIPTION
## Description

Add previously undocumented placeholders to docs

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

This pull request updates the documentation to include details about a new `-c --message-content` option for placeholders in post information. 

### Documentation Update:
* [`docs/source/usage.rst`](diffhunk://#diff-66e28562c85a1bb96f431f2dd52bbabab914359e4b06f58eb1e18eadc01f5c06R65-R75): Added a section describing the `-c --message-content` option, which supports placeholders for Instagram post details such as `{post_url}`, `{owner_url}`, `{owner_name}`, `{owner_username}`, `{post_caption}`, `{post_shortcode}`, and `{post_image_url}`.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->